### PR TITLE
Fix 1/2 #8 added rate flag. Required macos

### DIFF
--- a/fvid/fvid.py
+++ b/fvid/fvid.py
@@ -185,8 +185,7 @@ def make_video(output_filepath, image_sequence, framerate="1/5"):
             f"{FRAMES_DIR}encoded_frames*.png",
             pattern_type="glob",
             framerate=framerate,
-        ).output(outputfile, vcodec="libx264rgb").run(quiet=True)
-
+        ).output(outputfile, r=30, vcodec="libx264rgb").run(quiet=True)
 
 
 def cleanup():


### PR DESCRIPTION
@AlfredoSequeida this is fix 1 out of 2 needed for this bug. 

ffmpeg requires the -r flag to be set for the output file to work correctly. Here is the command I based this change off of. 

`ffmpeg -framerate 1 -pattern_type glob -i 'fvid_frames/encoded_frames*.png' -r 30 -vcodec libx264rgb out.mp4`

This produces the correct output (as far as I can tell) for the video. There is still an issue with the decoding (Lana only gets 50% decoded sadly). Going to bed will look more tomorrow. 